### PR TITLE
Fix secure backends deprecation

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: An Octobox chart for Kubernetes
 name: octobox
-version: 0.1.0
+version: 0.1.1

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Check the [values.yaml file](values.yaml) for all available configuration values
 | `nginx.tolerations`                         | Nginx container node tolerations               | `[]`                                             |
 | `nginx.affinity`                            | Nginx container node affinity                  | `{}`                                             |
 | `ingress.enabled`                           | Enable ingress                                 | `false`                                          |
-| `ingress.annotations`                       | Ingress annotations                            | `{kubernetes.io/ingress.class: nginx, nginx.ingress.kubernetes.io/secure-backends: "true"}` |
+| `ingress.annotations`                       | Ingress annotations                            | `{kubernetes.io/ingress.class: nginx, nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"}` |
 | `ingress.hosts`                             | Ingress hosts configuration                    | `[]`                                             |
 | `ingress.tls`                               | Ingress TLS configuration                      | `[]`                                             |
 

--- a/values.yaml
+++ b/values.yaml
@@ -109,7 +109,7 @@ ingress:
   enabled: false
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/secure-backends: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     #kubernetes.io/tls-acme: "true"
 
   hosts:


### PR DESCRIPTION
"nginx.ingress.kubernetes.io/secure-backends" was deprecated in `ingress-nginx` `0.18.0` and removed after the release of `0.20.0`.

See https://github.com/kubernetes/ingress-nginx/issues/3416.